### PR TITLE
Cast result to integer for Python 3 compatibility

### DIFF
--- a/python/examples/show_png.py
+++ b/python/examples/show_png.py
@@ -20,8 +20,8 @@ unicorn.brightness(0.4)
 
 img = Image.open('lofi.png')
 
-for o_x in range(img.size[0]/8):
-	for o_y in range(img.size[1]/8):
+for o_x in range(int(img.size[0]/8)):
+	for o_y in range(int(img.size[1]/8)):
 
 		for x in range(8):
 			for y in range(8):


### PR DESCRIPTION
The show_png script died under python 3 because of the change to division now returning a float.  I've added a cast to make it work (and it still works on python 2).

sudo python3.2 show_png.py 
Traceback (most recent call last):
  File "show_png.py", line 23, in <module>
    for o_x in range(img.size[0]/8):
TypeError: 'float' object cannot be interpreted as an integer